### PR TITLE
Fixed "MySQL server has gone away error"

### DIFF
--- a/powerdns-admin/bin/docker-entrypoint.sh
+++ b/powerdns-admin/bin/docker-entrypoint.sh
@@ -92,6 +92,7 @@ powerdns_admin_db_config() {
 SQLALCHEMY_DATABASE_URI = '${db_uri}'
 SQLALCHEMY_MIGRATE_REPO = '${APP_HOME}/migrations/powerdns-admin'
 SQLALCHEMY_TRACK_MODIFICATIONS = True
+SQLALCHEMY_POOL_RECYCLE = 600
 EOF
 }
 


### PR DESCRIPTION
Hi there,

My PowerDNS-Admin instance always runs into an `MySQL server has gone away error` exception so I googled the issue and found the following solution: https://github.com/ngoduykhanh/PowerDNS-Admin/issues/189
I tested it and I can confirm now, that this fix works. Instead of building and publishing an own (fixed) Docker image, I would like to see this fix merged into this already existing one.

Thanks.

Regards,
Philip 